### PR TITLE
Throw error if spurious' server is not running

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5,9 +5,11 @@ var url = require("url");
 var Strategy = require("./strategy");
 
 function port_config() {
-  var config = "spurious ports --json";
-  return JSON.parse(exec(config)) //err handling?
-  ;
+  var ports = exec("spurious ports --json");
+  if (ports == "[error] Spurious services haven't been started, please run 'spurious start'") {
+    throw new Error(ports);
+  }
+  return JSON.parse(ports);
 }
 
 function docker_config() {

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,11 @@ var url = require('url')
 var Strategy = require('./strategy')
 
 function port_config () {
-  let config = 'spurious ports --json'
-  return JSON.parse(exec(config)) //err handling?
+  const ports = exec('spurious ports --json')
+  if (ports == "[error] Spurious services haven't been started, please run 'spurious start'") {
+    throw new Error(ports);
+  }
+  return JSON.parse(ports)
 }
 
 function docker_config() {


### PR DESCRIPTION
Problem: Helper doesn't catch an error if spurious' server is not running, this is because spurious writes the error to stdout instead of stderr (https://github.com/spurious-io/spurious/issues/20).

Solution: Add a check against stdout for the error message that spurious writes.
