### PR TITLE
Added compatibility with Node 0.12

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,11 +1,26 @@
 "use strict";
 
-var exec = require("exec-sync");
 var url = require("url");
 var Strategy = require("./strategy");
 
+function get_ports() {
+  //  Use execSync if it exist (Node 0.12 and later) or exec-sync
+  var execSync = require("child_process").execSync || require("exec-sync");
+  var ports = execSync("spurious ports --json");
+  if (typeof ports === "string") {
+    return ports;
+  }
+
+  var Buffer = require("buffer").Buffer;
+  if (Buffer.isBuffer(ports)) {
+    return ports.toString();
+  }
+
+  return "[error] Spurious service returned an unsupported result: " + ports;
+}
+
 function port_config() {
-  var ports = exec("spurious ports --json");
+  var ports = get_ports();
   if (ports == "[error] Spurious services haven't been started, please run 'spurious start'") {
     throw new Error(ports);
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -16,7 +16,7 @@ function get_ports() {
     return ports.toString();
   }
 
-  return "[error] Spurious service returned an unsupported result: " + ports;
+  throw new Error(ports);
 }
 
 function port_config() {

--- a/dist/strategy.js
+++ b/dist/strategy.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var _prototypeProperties = function (child, staticProps, instanceProps) { if (staticProps) Object.defineProperties(child, staticProps); if (instanceProps) Object.defineProperties(child.prototype, instanceProps); };
+var _createClass = (function () { function defineProperties(target, props) { for (var key in props) { var prop = props[key]; prop.configurable = true; if (prop.value) prop.writable = true; } Object.defineProperties(target, props); } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
 var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
 
@@ -20,27 +20,21 @@ var Strategy = (function () {
     }
   }
 
-  _prototypeProperties(Strategy, null, {
+  _createClass(Strategy, {
     dynamo: {
       value: function dynamo() {
         this.mapping["spurious-dynamo"] = "dynamodb";
-      },
-      writable: true,
-      configurable: true
+      }
     },
     sqs: {
       value: function sqs() {
         this.mapping["spurious-sqs"] = "sqs";
-      },
-      writable: true,
-      configurable: true
+      }
     },
     s3: {
       value: function s3() {
         this.mapping["spurious-s3"] = "s3";
-      },
-      writable: true,
-      configurable: true
+      }
     },
     apply: {
       value: function apply(config) {
@@ -50,9 +44,7 @@ var Strategy = (function () {
             endpoint: ports[0].Host + ":" + ports[0].HostPort
           };
         }
-      },
-      writable: true,
-      configurable: true
+      }
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "email": "me@jakechampion.name",
     "url": "http://www.jakechampion.name/"
   },
-  "engines": {
-    "node": "<0.12"
-  },
   "files": [
     "dist"
   ],
@@ -31,7 +28,9 @@
     "AWS"
   ],
   "dependencies": {
-    "aws-sdk": "^2.1.8",
+    "aws-sdk": "^2.1.8"
+  },
+  "optionalDependencies": {
     "exec-sync": "^0.1.6"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,28 @@
-const exec = require('exec-sync')
 const url = require('url')
 const Strategy = require('./strategy')
 
+function get_ports() {
+  //  Use execSync if it exist (Node 0.12 and later) or exec-sync
+  const execSync = require('child_process').execSync || require('exec-sync');
+  const ports = execSync('spurious ports --json');
+  if (typeof ports === 'string') {
+    return ports;
+  }
+
+  const Buffer = require('buffer').Buffer;
+  if (Buffer.isBuffer(ports)) {
+    return ports.toString();
+  }
+  
+  return "[error] Spurious service returned an unsupported result: " + ports;
+}
+
 function port_config () {
-  const ports = exec('spurious ports --json')
+  const ports = get_ports();
   if (ports == "[error] Spurious services haven't been started, please run 'spurious start'") {
     throw new Error(ports);
   }
-  return JSON.parse(ports)
+  return JSON.parse(ports);
 }
 
 function docker_config() {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ function get_ports() {
     return ports.toString();
   }
   
-  return "[error] Spurious service returned an unsupported result: " + ports;
+  throw new Error(ports);
 }
 
 function port_config () {


### PR DESCRIPTION
Now compatible with 0.12 by using built-in execSync or, for previous versions, using exec-sync as before
